### PR TITLE
Add Composer type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
 	"description": "A library which provides extended functionality to WordPress template parts, including template variables and caching.",
 	"homepage"   : "https://github.com/johnbillion/extended-template-parts/",
 	"license"    : "GPL-2.0+",
+	"type"       : "wordpress-plugin",
 	"authors"    : [
 		{
 			"name"    : "John Blackbourn",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"description": "A library which provides extended functionality to WordPress template parts, including template variables and caching.",
 	"homepage"   : "https://github.com/johnbillion/extended-template-parts/",
 	"license"    : "GPL-2.0+",
-	"type"       : "wordpress-plugin",
+	"type"       : "wordpress-muplugin",
 	"authors"    : [
 		{
 			"name"    : "John Blackbourn",


### PR DESCRIPTION
In composer, you've added the `installers` library, which gets us close to allowing custom paths and correct package mapping, but according to https://getcomposer.org/doc/faqs/how-do-i-install-a-package-to-a-custom-path-for-my-framework.md the composer file also needs to declare a valid type for the mapping to occur.

Here, I've added a type of `wordpress-plugin` so that this will automatically be put in a site's `plugins` directory. I was tempted to declare it a `wordpress-muplugin` since it's a developer library but plugin felt more mainstream. I'm open to swapping it though.