### PR TITLE
Use template part vars in generating the cache key

### DIFF
--- a/src/extended-template-part.php
+++ b/src/extended-template-part.php
@@ -177,7 +177,7 @@ class Extended_Template_Part {
 	 * @return string The cache key.
 	 */
 	protected function cache_key() : string {
-		return 'part_' . md5( $this->locate_template() . '/' . wp_json_encode( $this->args ) );
+		return 'part_' . md5( $this->locate_template() . '/' . wp_json_encode( [ $this->vars, $this->args ] ) );
 	}
 
 }


### PR DESCRIPTION
Makes sure that separate calls to get_extended_template_part are cached separately by using the template vars passed into the request as part of the cache key hash generation.

Fixes #9.