### PR TITLE
Add filter to disable cache

### DIFF
--- a/src/extended-template-part.php
+++ b/src/extended-template-part.php
@@ -167,7 +167,8 @@ class Extended_Template_Part {
 	 * @return string|false The cached output, or boolean false if there is no cached version.
 	 */
 	protected function get_cache() {
-		return get_transient( $this->cache_key() );
+		$cache_enabled = apply_filters( 'extended_template_part_cache_enabled', true, $this->slug, $this->name, $this->args );
+		return $cache_enabled ? get_transient( $this->cache_key() ) : false;
 	}
 
 	/**


### PR DESCRIPTION
My use case - I'm using this library to cache some templates. However this is causing confusion as templates are cached locally and changes don't appear. Whilst it's great to be able to test this is working, I'd like to be able to just disable cache somehow on local environments. 

I was hesitant about the way to approach this because there is no precedent within the library for filter usage so I'd appreciate some feedback on the way I did it.